### PR TITLE
Assignment and db fix

### DIFF
--- a/mobile/lib/config/theme.dart
+++ b/mobile/lib/config/theme.dart
@@ -307,7 +307,7 @@ class AppTheme {
       ),
     ),
 
-    dialogTheme: DialogTheme(
+    dialogTheme: DialogThemeData(
       backgroundColor: Color(0xFF1C1C1C),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       titleTextStyle: TextStyle(
@@ -316,7 +316,7 @@ class AppTheme {
         fontWeight: FontWeight.w600,
       ),
       contentTextStyle: TextStyle(
-        color: Colors.white.withValues(alpha: 0.9),
+        color: Colors.white.withOpacity(0.9),
         fontSize: 14,
       ),
     ),

--- a/mobile/lib/models/person.dart
+++ b/mobile/lib/models/person.dart
@@ -46,11 +46,11 @@ class Person {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     return other is Person &&
-        name == other.name &&
+        name.toLowerCase() == other.name.toLowerCase() &&
         color.toARGB32() == other.color.toARGB32();
   }
 
   //If you override ==, you must override hashCode
   @override
-  int get hashCode => name.hashCode ^ color.toARGB32().hashCode;
+  int get hashCode => name.toLowerCase().hashCode ^ color.toARGB32().hashCode;
 }

--- a/mobile/lib/screens/quick_split/bill_entry/models/bill_data.dart
+++ b/mobile/lib/screens/quick_split/bill_entry/models/bill_data.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/material.dart';
 import '/models/bill_item.dart';
+import '/models/person.dart';
 
 /// BillData - ChangeNotifier class that manages bill calculation state
 ///
@@ -53,6 +54,14 @@ class BillData extends ChangeNotifier {
   // Items total tracking
   double itemsTotal = 0.0;
   double animatedItemsTotal = 0.0;
+
+  // Birthday person tracking
+  Person? _birthdayPerson;
+  Person? get birthdayPerson => _birthdayPerson;
+  set birthdayPerson(Person? person) {
+    _birthdayPerson = person;
+    notifyListeners();
+  }
 
   BillData() {
     // Add listeners to controllers for real-time calculation updates

--- a/mobile/lib/screens/quick_split/bill_entry/models/bill_data.dart
+++ b/mobile/lib/screens/quick_split/bill_entry/models/bill_data.dart
@@ -146,4 +146,17 @@ class BillData extends ChangeNotifier {
     useCustomTipAmount = value;
     calculateBill();
   }
+
+  /// Updates the items list with new items that may have assignments
+  void updateItems(List<BillItem> newItems) {
+    // Clear current items
+    items.clear();
+    
+    // Add all new items with their assignments
+    items.addAll(newItems);
+    
+    // Recalculate totals
+    calculateItemsTotal();
+    notifyListeners();
+  }
 }

--- a/mobile/lib/screens/quick_split/item_assignment/item_assignment_screen.dart
+++ b/mobile/lib/screens/quick_split/item_assignment/item_assignment_screen.dart
@@ -35,6 +35,7 @@ import 'package:checks_frontend/screens/quick_split/bill_summary/bill_summary_sc
 // Provider and utils
 import 'providers/assignment_provider.dart';
 import 'utils/assignment_utils.dart';
+import 'models/assignment_result.dart';
 
 // Screen that allows users to assign bill items to participants
 // Shows a list of items with options to split them among people
@@ -51,6 +52,7 @@ class ItemAssignmentScreen extends StatefulWidget {
   final double tipPercentage;
   // Whether tip was entered as a custom amount rather than percentage
   final bool isCustomTipAmount;
+  final Person? initialBirthdayPerson;
 
   const ItemAssignmentScreen({
     super.key,
@@ -62,6 +64,7 @@ class ItemAssignmentScreen extends StatefulWidget {
     required this.total,
     required this.tipPercentage,
     required this.isCustomTipAmount,
+    this.initialBirthdayPerson,
   });
 
   @override
@@ -272,14 +275,21 @@ class _ItemAssignmentScreenState extends State<ItemAssignmentScreen>
             total: widget.total,
             tipPercentage: widget.tipPercentage,
             isCustomTipAmount: widget.isCustomTipAmount,
+            initialBirthdayPerson: widget.initialBirthdayPerson,
           ),
       child: Consumer<AssignmentProvider>(
         builder: (context, provider, _) {
           return Scaffold(
             appBar: AssignmentAppBar(
               onBackPressed: () {
-                // Return updated item assignments when navigating back
-                Navigator.pop(context, provider.items);
+                // Return updated item assignments and birthday person when navigating back
+                Navigator.pop(
+                  context,
+                  AssignmentResult(
+                    items: provider.items,
+                    birthdayPerson: provider.birthdayPerson,
+                  ),
+                );
               },
               onHelpPressed:
                   _tutorialManagerInitialized

--- a/mobile/lib/screens/quick_split/item_assignment/item_assignment_screen.dart
+++ b/mobile/lib/screens/quick_split/item_assignment/item_assignment_screen.dart
@@ -277,7 +277,10 @@ class _ItemAssignmentScreenState extends State<ItemAssignmentScreen>
         builder: (context, provider, _) {
           return Scaffold(
             appBar: AssignmentAppBar(
-              onBackPressed: () => Navigator.pop(context),
+              onBackPressed: () {
+                // Return updated item assignments when navigating back
+                Navigator.pop(context, provider.items);
+              },
               onHelpPressed:
                   _tutorialManagerInitialized
                       ? () => _tutorialManager.showTutorial(context)

--- a/mobile/lib/screens/quick_split/item_assignment/models/assignment_data.dart
+++ b/mobile/lib/screens/quick_split/item_assignment/models/assignment_data.dart
@@ -147,6 +147,7 @@ class AssignmentData {
   /// @param total Total bill amount
   /// @param tipPercentage Tip as percentage of subtotal
   /// @param isCustomTipAmount Whether tip was entered as amount or percentage
+  /// @param birthdayPerson Birthday person
   ///
   /// @return A new AssignmentData instance with empty/initial state values
   factory AssignmentData.initial({
@@ -158,6 +159,7 @@ class AssignmentData {
     required double total,
     required double tipPercentage,
     required bool isCustomTipAmount,
+    Person? birthdayPerson,
   }) {
     return AssignmentData(
       participants: participants,
@@ -173,7 +175,7 @@ class AssignmentData {
       unassignedAmount:
           items.isEmpty ? 0.0 : subtotal, // All items unassigned initially
       selectedPerson: null, // No person selected initially
-      birthdayPerson: null, // No birthday person initially
+      birthdayPerson: birthdayPerson, // Use provided birthday person
     );
   }
 }

--- a/mobile/lib/screens/quick_split/item_assignment/models/assignment_result.dart
+++ b/mobile/lib/screens/quick_split/item_assignment/models/assignment_result.dart
@@ -1,0 +1,13 @@
+import '/models/bill_item.dart';
+import '/models/person.dart';
+
+/// Data class to hold the result of item assignment, including items and birthday person
+class AssignmentResult {
+  final List<BillItem> items;
+  final Person? birthdayPerson;
+
+  const AssignmentResult({
+    required this.items,
+    this.birthdayPerson,
+  });
+} 

--- a/mobile/lib/screens/quick_split/item_assignment/providers/assignment_provider.dart
+++ b/mobile/lib/screens/quick_split/item_assignment/providers/assignment_provider.dart
@@ -32,8 +32,7 @@ import '/models/bill_item.dart';
 /// It uses the AssignmentData immutable data class to store the current state
 /// and AssignmentUtils to perform calculations.
 class AssignmentProvider extends ChangeNotifier {
-  // The current state of assignments
-  AssignmentData _data;
+  late AssignmentData _data;
 
   // Icons used for categorizing bill items
   final IconData universalItemIcon =
@@ -50,6 +49,7 @@ class AssignmentProvider extends ChangeNotifier {
   /// @param total Total bill amount (subtotal + tax + tip)
   /// @param tipPercentage Tip as percentage of subtotal
   /// @param isCustomTipAmount Whether tip was entered as amount (true) or percentage (false)
+  /// @param initialBirthdayPerson The initial birthday person for the bill
   AssignmentProvider({
     required List<Person> participants,
     required List<BillItem> items,
@@ -59,16 +59,21 @@ class AssignmentProvider extends ChangeNotifier {
     required double total,
     required double tipPercentage,
     required bool isCustomTipAmount,
-  }) : _data = AssignmentData.initial(
-         participants: participants,
-         items: items,
-         subtotal: subtotal,
-         tax: tax,
-         tipAmount: tipAmount,
-         total: total,
-         tipPercentage: tipPercentage,
-         isCustomTipAmount: isCustomTipAmount,
-       ) {
+    Person? initialBirthdayPerson,
+  }) {
+    // Initialize data with provided values
+    _data = AssignmentData.initial(
+      participants: participants,
+      items: items,
+      subtotal: subtotal,
+      tax: tax,
+      tipAmount: tipAmount,
+      total: total,
+      tipPercentage: tipPercentage,
+      isCustomTipAmount: isCustomTipAmount,
+      birthdayPerson: initialBirthdayPerson,
+    );
+
     // Check if items already have assignments
     bool hasExistingAssignments = false;
     for (var item in items) {


### PR DESCRIPTION
This pull request introduces several updates across the codebase to enhance functionality, improve user experience, and fix inconsistencies. The most significant changes include adding birthday person tracking, refining item assignment handling, and improving equality checks for the `Person` model. Below is a categorized summary of the most important changes:

### Theme Updates
* Changed `DialogTheme` to `DialogThemeData` and replaced `withValues(alpha: 0.9)` with `withOpacity(0.9)` for better readability and consistency in `theme.dart`. [[1]](diffhunk://#diff-2c751fb724f6d2ee3caeb479003ea1a3b540ce2129b13d185addd6c847255b5aL310-R310) [[2]](diffhunk://#diff-2c751fb724f6d2ee3caeb479003ea1a3b540ce2129b13d185addd6c847255b5aL319-R319)

### Database Enhancements
* Added logic to prevent duplicate bills from being saved within a one-minute window in `database.dart`. This ensures data integrity and avoids redundant entries.

### Equality and Hashing Improvements
* Updated the equality (`==`) and `hashCode` implementations in the `Person` model to perform case-insensitive comparisons for names, ensuring more robust and accurate comparisons.

### Item Assignment Enhancements
* Introduced deep copying of item assignments when navigating between screens in the `BillEntryScreen` to preserve data integrity.
* Added a new `AssignmentResult` class to encapsulate item assignments and the birthday person, facilitating cleaner data handling across screens.
* Updated the `ItemAssignmentScreen` to return item assignments and the birthday person upon navigation back, improving state management.

### Birthday Person Tracking
* Added support for tracking the birthday person in `BillData`, `AssignmentProvider`, and related models, enabling personalized features in the bill-splitting workflow. [[1]](diffhunk://#diff-fd9bf7e5b47383e9561261fc643c875cbb9a2b629ea59a3cb22552d1047ee453R58-R65) [[2]](diffhunk://#diff-ff96ff50db3858415545c0fe795337e2960c882cf48a91c71f11c8b3fc717d43R55) [[3]](diffhunk://#diff-830385dad0a4858d672a2854268d819cea0a5862d45e70aa76570793d99f34dcL62-R65)