### PR TITLE
fix: correct bounding box misalignment from EXIF rotation

### DIFF
--- a/mobile/lib/services/mlkit_ocr_service.dart
+++ b/mobile/lib/services/mlkit_ocr_service.dart
@@ -16,6 +16,7 @@
 //     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'dart:io';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 
@@ -30,9 +31,16 @@ class OcrTextLine {
 class OcrResult {
   final String fullText;
   final List<OcrTextLine> lines;
+
+  /// Image dimensions as displayed (post-EXIF rotation).
+  /// This matches how Flutter's Image.file renders the photo.
   final ui.Size imageSize;
-  const OcrResult(
-      {required this.fullText, required this.lines, required this.imageSize});
+
+  const OcrResult({
+    required this.fullText,
+    required this.lines,
+    required this.imageSize,
+  });
 }
 
 /// Runs on-device OCR via Google ML Kit.
@@ -41,8 +49,26 @@ class MlkitOcrService {
 
   Future<OcrResult> recognizeText(String imagePath) async {
     try {
+      final bytes = await File(imagePath).readAsBytes();
+
+      // Read EXIF orientation to determine if width/height are swapped
+      final exifOrientation = _readExifOrientation(bytes);
+      final isRotated = exifOrientation >= 5 && exifOrientation <= 8;
+
+      // Get raw pixel dimensions
+      final codec = await ui.instantiateImageCodec(bytes);
+      final frame = await codec.getNextFrame();
+      final rawW = frame.image.width.toDouble();
+      final rawH = frame.image.height.toDouble();
+      frame.image.dispose();
+      codec.dispose();
+
+      // Display size: Flutter auto-applies EXIF rotation, so swap if rotated
+      final displaySize = isRotated ? ui.Size(rawH, rawW) : ui.Size(rawW, rawH);
+
+      // ML Kit processes with InputImage.fromFilePath which reads EXIF
+      // and returns bounding boxes in the display-oriented coordinate system.
       final inputImage = InputImage.fromFilePath(imagePath);
-      final imageSize = await _resolveImageSize(imagePath);
       final recognized = await _recognizer.processImage(inputImage);
 
       final lines = <OcrTextLine>[];
@@ -56,21 +82,86 @@ class MlkitOcrService {
       }
 
       final fullText = recognized.blocks.map((b) => b.text).join('\n');
-      return OcrResult(fullText: fullText, lines: lines, imageSize: imageSize);
+      return OcrResult(
+          fullText: fullText, lines: lines, imageSize: displaySize);
     } catch (e) {
       throw OcrException('OCR failed for $imagePath: $e');
     }
   }
 
-  Future<ui.Size> _resolveImageSize(String imagePath) async {
-    final bytes = await File(imagePath).readAsBytes();
-    final codec = await ui.instantiateImageCodec(bytes);
-    final frame = await codec.getNextFrame();
-    final size = ui.Size(
-        frame.image.width.toDouble(), frame.image.height.toDouble());
-    frame.image.dispose();
-    codec.dispose();
-    return size;
+  /// Read EXIF orientation tag from JPEG bytes.
+  /// Returns 1-8 (1 = normal, 6 = rotated 90° CW, 8 = rotated 90° CCW).
+  /// Returns 1 (normal) if not a JPEG or tag not found.
+  int _readExifOrientation(Uint8List bytes) {
+    if (bytes.length < 12) return 1;
+    // Check JPEG SOI marker
+    if (bytes[0] != 0xFF || bytes[1] != 0xD8) return 1;
+
+    var offset = 2;
+    while (offset < bytes.length - 4) {
+      if (bytes[offset] != 0xFF) return 1;
+      final marker = bytes[offset + 1];
+
+      // APP1 marker (EXIF)
+      if (marker == 0xE1) {
+        final exifStart = offset + 4;
+
+        // Check "Exif\0\0"
+        if (exifStart + 6 > bytes.length) return 1;
+        if (bytes[exifStart] != 0x45 ||
+            bytes[exifStart + 1] != 0x78 ||
+            bytes[exifStart + 2] != 0x69 ||
+            bytes[exifStart + 3] != 0x66) {
+          return 1;
+        }
+
+        final tiffStart = exifStart + 6;
+        if (tiffStart + 8 > bytes.length) return 1;
+
+        // Determine byte order
+        final bigEndian = bytes[tiffStart] == 0x4D; // 'M' = big endian
+
+        int read16(int pos) {
+          if (pos + 2 > bytes.length) return 0;
+          return bigEndian
+              ? (bytes[pos] << 8) | bytes[pos + 1]
+              : bytes[pos] | (bytes[pos + 1] << 8);
+        }
+
+        // Read IFD0 offset
+        final ifdOffset = bigEndian
+            ? (bytes[tiffStart + 4] << 24) |
+                (bytes[tiffStart + 5] << 16) |
+                (bytes[tiffStart + 6] << 8) |
+                bytes[tiffStart + 7]
+            : bytes[tiffStart + 4] |
+                (bytes[tiffStart + 5] << 8) |
+                (bytes[tiffStart + 6] << 16) |
+                (bytes[tiffStart + 7] << 24);
+
+        final ifdPos = tiffStart + ifdOffset;
+        if (ifdPos + 2 > bytes.length) return 1;
+
+        final numEntries = read16(ifdPos);
+        for (var i = 0; i < numEntries; i++) {
+          final entryPos = ifdPos + 2 + (i * 12);
+          if (entryPos + 12 > bytes.length) return 1;
+
+          final tag = read16(entryPos);
+          if (tag == 0x0112) {
+            // Orientation tag
+            return read16(entryPos + 8);
+          }
+        }
+        return 1;
+      }
+
+      // Skip to next segment
+      final segLen =
+          (bytes[offset + 2] << 8) | bytes[offset + 3];
+      offset += 2 + segLen;
+    }
+    return 1;
   }
 
   void dispose() {

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: checks_frontend
 description: "Billington — privacy-first receipt splitting"
 publish_to: 'none'
-version: 1.2.0+5
+version: 1.2.0+6
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
## Summary

Fixes bounding box overlays appearing in wrong positions on the Compare Receipt screen.

**Root cause**: `_resolveImageSize` used `instantiateImageCodec` which returns raw pixel dimensions (before EXIF rotation). Phone camera photos are stored as landscape with EXIF rotation metadata. Flutter's `Image.file` auto-applies EXIF rotation when displaying, but the bounding box coordinates were normalized against the unrotated dimensions — causing width/height to be swapped and all overlays to land in wrong positions.

**Fix**: Read the EXIF orientation tag from JPEG bytes and swap width/height for rotated orientations (5-8), so `imageSize` matches the display dimensions that Flutter uses.

## Test plan

- [ ] Scan a receipt photo taken in portrait orientation
- [ ] Verify bounding boxes align with the actual text lines on the receipt
- [ ] `flutter analyze` clean, `flutter test` 154/154 pass