### PR TITLE
Fix tab bill attachment validation

### DIFF
--- a/backend/internal/tab/handler.go
+++ b/backend/internal/tab/handler.go
@@ -75,7 +75,7 @@ func (h *TabHandler) getTabAndValidate(c *gin.Context) *models.Tab {
 }
 
 // getMemberFromQuery reads the member token from X-Member-Token header or ?m= query param.
-func (h *TabHandler) getMemberFromQuery(c *gin.Context) *models.TabMember {
+func (h *TabHandler) getMemberFromQuery(c *gin.Context, tabID uint) *models.TabMember {
 	memberToken := c.GetHeader("X-Member-Token")
 	if memberToken == "" {
 		memberToken = c.Query("m")
@@ -87,14 +87,17 @@ func (h *TabHandler) getMemberFromQuery(c *gin.Context) *models.TabMember {
 	if err != nil {
 		return nil
 	}
+	if member.TabID != tabID {
+		return nil
+	}
 	return member
 }
 
 func (h *TabHandler) CreateTab(c *gin.Context) {
 	var body struct {
-		Name                string `json:"name"`
-		Description         string `json:"description"`
-		CreatorDisplayName  string `json:"creator_display_name"`
+		Name               string `json:"name"`
+		Description        string `json:"description"`
+		CreatorDisplayName string `json:"creator_display_name"`
 	}
 
 	if err := c.ShouldBindJSON(&body); err != nil {
@@ -162,7 +165,8 @@ func (h *TabHandler) AddBillToTab(c *gin.Context) {
 	}
 
 	var body struct {
-		BillID uint `json:"bill_id"`
+		BillID    uint   `json:"bill_id"`
+		BillToken string `json:"bill_token"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(400, gin.H{"error": "bad request"})
@@ -170,11 +174,11 @@ func (h *TabHandler) AddBillToTab(c *gin.Context) {
 	}
 
 	var memberID *uint
-	if member := h.getMemberFromQuery(c); member != nil {
+	if member := h.getMemberFromQuery(c, tab.ID); member != nil {
 		memberID = &member.ID
 	}
 
-	err := h.service.AddBillToTab(tab.ID, body.BillID, memberID)
+	err := h.service.AddBillToTab(tab.ID, body.BillID, body.BillToken, memberID)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			c.JSON(404, gin.H{"error": "bill not found"})
@@ -236,7 +240,7 @@ func (h *TabHandler) FinalizeTab(c *gin.Context) {
 
 	// If tab has members, only the creator can finalize
 	if len(tab.Members) > 0 {
-		member := h.getMemberFromQuery(c)
+		member := h.getMemberFromQuery(c, tab.ID)
 		if member == nil || member.Role != "creator" {
 			c.JSON(403, gin.H{"error": "only the tab creator can finalize"})
 			return

--- a/backend/internal/tab/repository.go
+++ b/backend/internal/tab/repository.go
@@ -12,7 +12,7 @@ type TabRepository interface {
 	GetById(id uint) (tab *models.Tab, err error)
 	Update(tab *models.Tab) error
 	Delete(id uint) error
-	AddBill(tabID uint, billID uint, memberID *uint) error
+	AddBill(tabID uint, billID uint, billToken string, memberID *uint) error
 	Finalize(id uint) error
 	GetSettlements(tabID uint) ([]models.TabSettlement, error)
 	CreateSettlements(settlements []models.TabSettlement) error
@@ -52,13 +52,15 @@ func (r *tabRepository) Delete(id uint) error {
 	return r.db.Delete(&models.Tab{}, id).Error
 }
 
-func (r *tabRepository) AddBill(tabID uint, billID uint, memberID *uint) error {
+func (r *tabRepository) AddBill(tabID uint, billID uint, billToken string, memberID *uint) error {
 	updates := map[string]interface{}{"tab_id": tabID}
 	if memberID != nil {
 		updates["added_by_member_id"] = *memberID
 		updates["paid_by_member_id"] = *memberID
 	}
-	result := r.db.Model(&models.Bill{}).Where("id = ?", billID).Updates(updates)
+	result := r.db.Model(&models.Bill{}).
+		Where("id = ? AND access_token = ? AND (tab_id IS NULL OR tab_id = ?)", billID, billToken, tabID).
+		Updates(updates)
 	if result.Error != nil {
 		return result.Error
 	}

--- a/backend/internal/tab/service.go
+++ b/backend/internal/tab/service.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // ImageQuerier provides read access to tab images without importing the image package.
@@ -20,7 +22,7 @@ type TabService interface {
 	CreateTab(tab *models.Tab) error
 	GetTab(id uint) (tab *models.Tab, err error)
 	UpdateTab(tab *models.Tab) error
-	AddBillToTab(tabID uint, billID uint, memberID *uint) error
+	AddBillToTab(tabID uint, billID uint, billToken string, memberID *uint) error
 	FinalizeTab(id uint) ([]models.TabSettlement, error)
 	GetSettlements(tabID uint) ([]models.TabSettlement, error)
 	UpdateSettlementPaid(id uint, paid bool) error
@@ -59,8 +61,11 @@ func (s *tabService) UpdateTab(tab *models.Tab) error {
 	return s.repo.Update(tab)
 }
 
-func (s *tabService) AddBillToTab(tabID uint, billID uint, memberID *uint) error {
-	return s.repo.AddBill(tabID, billID, memberID)
+func (s *tabService) AddBillToTab(tabID uint, billID uint, billToken string, memberID *uint) error {
+	if strings.TrimSpace(billToken) == "" {
+		return gorm.ErrRecordNotFound
+	}
+	return s.repo.AddBill(tabID, billID, billToken, memberID)
 }
 
 func (s *tabService) FinalizeTab(id uint) ([]models.TabSettlement, error) {

--- a/backend/internal/tab/service_test.go
+++ b/backend/internal/tab/service_test.go
@@ -28,12 +28,13 @@ type mockTabRepository struct {
 	getMembersByTabIDErr error
 
 	// Capture calls
-	addBillTabID    uint
-	addBillBillID   uint
-	addBillMemberID     *uint
+	addBillTabID          uint
+	addBillBillID         uint
+	addBillBillToken      string
+	addBillMemberID       *uint
 	addBillPaidByMemberID *uint
-	finalizedID         uint
-	createdSettlements []models.TabSettlement
+	finalizedID           uint
+	createdSettlements    []models.TabSettlement
 }
 
 func newMockRepo() *mockTabRepository {
@@ -62,12 +63,13 @@ func (m *mockTabRepository) GetById(id uint) (*models.Tab, error) {
 	return tab, nil
 }
 
-func (m *mockTabRepository) Update(tab *models.Tab) error  { return m.updateErr }
-func (m *mockTabRepository) Delete(id uint) error          { return m.deleteErr }
+func (m *mockTabRepository) Update(tab *models.Tab) error { return m.updateErr }
+func (m *mockTabRepository) Delete(id uint) error         { return m.deleteErr }
 
-func (m *mockTabRepository) AddBill(tabID uint, billID uint, memberID *uint) error {
+func (m *mockTabRepository) AddBill(tabID uint, billID uint, billToken string, memberID *uint) error {
 	m.addBillTabID = tabID
 	m.addBillBillID = billID
+	m.addBillBillToken = billToken
 	m.addBillMemberID = memberID
 	m.addBillPaidByMemberID = memberID
 	return m.addBillErr
@@ -321,7 +323,7 @@ func TestAddBillToTab_WithMember(t *testing.T) {
 
 	svc := NewTabService(repo, imgQ)
 	memberID := uint(42)
-	err := svc.AddBillToTab(1, 99, &memberID)
+	err := svc.AddBillToTab(1, 99, "bill-token", &memberID)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -331,6 +333,9 @@ func TestAddBillToTab_WithMember(t *testing.T) {
 	}
 	if repo.addBillBillID != 99 {
 		t.Errorf("expected billID 99, got %d", repo.addBillBillID)
+	}
+	if repo.addBillBillToken != "bill-token" {
+		t.Errorf("expected bill token to be passed through, got %q", repo.addBillBillToken)
 	}
 	if repo.addBillMemberID == nil || *repo.addBillMemberID != 42 {
 		t.Error("expected memberID 42 to be passed through")
@@ -345,13 +350,27 @@ func TestAddBillToTab_SetsPaidByMemberID(t *testing.T) {
 
 	svc := NewTabService(repo, imgQ)
 	memberID := uint(42)
-	err := svc.AddBillToTab(1, 99, &memberID)
+	err := svc.AddBillToTab(1, 99, "bill-token", &memberID)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	if repo.addBillPaidByMemberID == nil || *repo.addBillPaidByMemberID != 42 {
 		t.Error("expected PaidByMemberID 42 to be set when adding bill with member")
+	}
+}
+
+func TestAddBillToTab_RequiresBillToken(t *testing.T) {
+	repo := newMockRepo()
+	imgQ := &mockImageQuerier{}
+	svc := NewTabService(repo, imgQ)
+
+	err := svc.AddBillToTab(1, 99, "", nil)
+	if err == nil {
+		t.Fatal("expected error for missing bill token")
+	}
+	if repo.addBillBillID != 0 {
+		t.Fatalf("expected repository not to be called, got bill id %d", repo.addBillBillID)
 	}
 }
 

--- a/mobile/lib/screens/tabs/tab_manager.dart
+++ b/mobile/lib/screens/tabs/tab_manager.dart
@@ -99,11 +99,18 @@ class TabManager extends ChangeNotifier {
       // Fire-and-forget backend sync for each bill
       if (tabData.accessToken != null && tabData.backendId != null) {
         final apiService = ApiService();
-        for (final billId in billIds) {
+        for (final localBillId in billIds) {
+          final billData = await DatabaseProvider.db.getBillById(localBillId);
+          final backendBill = _parseBillShareUrl(billData?.shareUrl);
+          if (backendBill == null) {
+            debugPrint('Skipping backend tab sync for bill without share URL');
+            continue;
+          }
           apiService.addBillToTab(
             tabData.backendId!,
-            billId,
+            backendBill.id,
             tabData.accessToken!,
+            billToken: backendBill.token,
           );
         }
       }
@@ -285,4 +292,25 @@ class TabManager extends ChangeNotifier {
       isRemote: tabData.isRemote,
     );
   }
+
+  _BackendBillRef? _parseBillShareUrl(String? shareUrl) {
+    if (shareUrl == null || shareUrl.isEmpty) return null;
+
+    final uri = Uri.tryParse(shareUrl);
+    if (uri == null || uri.pathSegments.length < 2) return null;
+    if (uri.pathSegments[uri.pathSegments.length - 2] != 'b') return null;
+
+    final billId = int.tryParse(uri.pathSegments.last);
+    final token = uri.queryParameters['t'];
+    if (billId == null || token == null || token.isEmpty) return null;
+
+    return _BackendBillRef(billId, token);
+  }
+}
+
+class _BackendBillRef {
+  final int id;
+  final String token;
+
+  const _BackendBillRef(this.id, this.token);
 }

--- a/mobile/lib/services/api_service.dart
+++ b/mobile/lib/services/api_service.dart
@@ -171,6 +171,7 @@ class ApiService {
     int tabId,
     int billId,
     String accessToken, {
+    required String billToken,
     String? memberToken,
   }) async {
     try {
@@ -185,7 +186,7 @@ class ApiService {
       final response = await http.post(
         Uri.parse('$baseUrl/api/tabs/$tabId/bills'),
         headers: headers,
-        body: jsonEncode({'bill_id': billId}),
+        body: jsonEncode({'bill_id': billId, 'bill_token': billToken}),
       ).timeout(_timeout);
 
       if (response.statusCode == 200) {

--- a/web-bill-viewer/src/app/b/[id]/loading.tsx
+++ b/web-bill-viewer/src/app/b/[id]/loading.tsx
@@ -58,6 +58,9 @@ export default function Loading() {
               <p className="text-sm text-[var(--text-secondary)]">
                 Loading your bill...
               </p>
+              <p className="mt-1 max-w-xs text-center text-xs text-[var(--text-secondary)]">
+                If this takes a moment, the backend is probably waking up.
+              </p>
             </div>
           </main>
         </div>

--- a/web-bill-viewer/src/components/BillPageClient.tsx
+++ b/web-bill-viewer/src/components/BillPageClient.tsx
@@ -99,6 +99,9 @@ export default function BillPageClient({ id, token }: BillPageClientProps) {
           <p className="text-sm text-[var(--text-secondary)]">
             Loading your bill...
           </p>
+          <p className="mt-1 max-w-xs text-xs text-[var(--text-secondary)]">
+            If this takes a moment, the backend is probably waking up.
+          </p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- attach tab bills using backend bill id and bill token, not local SQLite ids
- require bill token validation on backend tab bill attachment
- add cold-start copy to the bill viewer loading states

## Tests
- go test ./internal/tab ./internal/bill
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bill viewer loading screens now include helpful messaging informing users that the backend may be initializing, providing better context during longer load times.

* **Improvements**
  * Bill-to-tab assignment now incorporates token-based verification, strengthening security and ensuring more reliable synchronization of shared bills across all platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LLRHook/checksinmyhead/pull/113)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->