### PR TITLE
Bump app version to 1.2.0+8

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: checks_frontend
 description: "Billington — privacy-first receipt splitting"
 publish_to: 'none'
-version: 1.2.0+7
+version: 1.2.0+8
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
## Summary
- bump Flutter app version from 1.2.0+7 to 1.2.0+8

## Tests
- not run; version-only change